### PR TITLE
Fixed Str class import

### DIFF
--- a/src/Controllers/ChatterDiscussionController.php
+++ b/src/Controllers/ChatterDiscussionController.php
@@ -11,6 +11,7 @@ use Event;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as Controller;
 use Validator;
+use Illuminate\Support\Str;
 
 class ChatterDiscussionController extends Controller
 {
@@ -103,7 +104,7 @@ class ChatterDiscussionController extends Controller
         }
 
         // *** Let's gaurantee that we always have a generic slug *** //
-        $slug = \Str::slug($request->title, '-');
+        $slug = Str::slug($request->title, '-');
 
         $discussion_exists = Models::discussion()->where('slug', '=', $slug)->withTrashed()->first();
         $incrementer = 1;


### PR DESCRIPTION
Fixed breaking bug that didn't allow to create new discussion because of missing import of `Str` class. Image of the mentioned bud: 

![image](https://user-images.githubusercontent.com/36918435/81933247-5e4b4380-95ed-11ea-8388-6fd8748fc1fc.png)
